### PR TITLE
Added test to benchmark submission endpoint

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,5 +33,5 @@ jobs:
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        run: python3 APITests/manifest-generator.py
+        run: python3 APITests/manifest-generator.py APITests/manifest-submit.py APITests/manifest-validate.py 
 

--- a/APITests/manifest-submit.py
+++ b/APITests/manifest-submit.py
@@ -26,7 +26,7 @@ class ManifestSubmit:
             "input_token": self.token,
         }
 
-    def submit_example_manifeset_patient_as_table_and_file(self):
+    def submit_example_manifeset_patient(self):
         """
         submitting an example data manifest
         """
@@ -60,4 +60,4 @@ class ManifestSubmit:
 
 
 sm_example_manifest = ManifestSubmit(EXAMPLE_SCHEMA_URL)
-sm_example_manifest.submit_example_manifeset_patient_as_table_and_file()
+sm_example_manifest.submit_example_manifeset_patient()

--- a/APITests/manifest-submit.py
+++ b/APITests/manifest-submit.py
@@ -1,0 +1,63 @@
+from utils import (
+    get_input_token,
+    record_run_time_result,
+    send_example_patient_manifest,
+    send_post_request,
+)
+from utils import HTAN_SCHEMA_URL, EXAMPLE_SCHEMA_URL, BASE_URL
+import time
+
+CONCURRENT_THREADS = 1
+base_url = f"{BASE_URL}/model/submit"
+
+
+class ManifestSubmit:
+    def __init__(self, url):
+        self.schema_url = url
+        self.dataset_id = "syn51376664"
+        self.token = get_input_token()
+        self.asset_view = "syn51376649"
+
+        # organize parameters for submitting a manifest
+        self.params = {
+            "schema_url": self.schema_url,
+            "dataset_id": self.dataset_id,
+            "asset_view": self.asset_view,
+            "input_token": self.token,
+        }
+
+    def submit_example_manifeset_patient_as_table_and_file(self):
+        """
+        submitting an example data manifest
+        """
+        params = self.params
+        # update parameter.
+        params["table_manipulation"] = "replace"
+        params["restrict_rules"] = False
+        params["use_schema_label"] = True
+
+        # try submitting a manifest with and without validation and with different record type
+        data_type_lst = ["Patient", None]
+        record_type_lst = ["table_and_file", "file_only"]
+        for opt in data_type_lst:
+            for record_type in record_type_lst:
+                params["data_type"] = opt
+                params["manifest_record_type"] = record_type
+
+                dt_string, time_diff, status_code_dict = send_post_request(
+                    params, base_url, CONCURRENT_THREADS, send_example_patient_manifest
+                )
+
+                record_run_time_result(
+                    "model/submit",
+                    dt_string,
+                    f"Submitting an example patient manifest as {record_type} with validation set to {opt}. The manifest has 600 rows.",
+                    time_diff,
+                    CONCURRENT_THREADS,
+                    status_code_dict,
+                )
+                time.sleep(2)
+
+
+sm_example_manifest = ManifestSubmit(EXAMPLE_SCHEMA_URL)
+sm_example_manifest.submit_example_manifeset_patient_as_table_and_file()

--- a/APITests/manifest-validate.py
+++ b/APITests/manifest-validate.py
@@ -1,5 +1,9 @@
 import requests
-from utils import cal_time_api_call_post_request, record_run_time_result
+from utils import (
+    record_run_time_result,
+    send_example_patient_manifest,
+    send_post_request,
+)
 from utils import HTAN_SCHEMA_URL, EXAMPLE_SCHEMA_URL, BASE_URL
 
 CONCURRENT_THREADS = 2
@@ -17,21 +21,6 @@ class ValidateManifest:
         }
 
     @staticmethod
-    def send_example_patient_manifest_to_validate(url: str, params: dict):
-        """
-        sending an example patient manifest to validate
-        """
-        return requests.post(
-            url,
-            params=params,
-            files={
-                "file_name": open(
-                    "test_manifests/synapse_storage_manifest_patient.csv", "rb"
-                )
-            },
-        )
-
-    @staticmethod
     def send_HTAN_biospecimen_manifest_to_validate(url: str, params: dict):
         """
         sending a HTAN biospecimen manifest to validate
@@ -46,28 +35,6 @@ class ValidateManifest:
             },
         )
 
-    def send_post_request(self, manifest_to_validate_funct):
-        """
-        sending post requests to manifest/validate endpoint
-        Args:
-            manifest_to_validate_funct: a function; a function call that determines
-        Return:
-            dt_string: start time of running the API endpoints.
-            time_diff: time of finish running all requests.
-            all_status_code: dict; a dictionary that records the status code of run.
-        """
-        try:
-            # send request and calculate run time
-            dt_string, time_diff, status_code_dict = cal_time_api_call_post_request(
-                base_url, self.params, CONCURRENT_THREADS, manifest_to_validate_funct
-            )
-        # TO DO: add more details about raising different exception
-        # Should exception based on response type?
-        except Exception as err:
-            print(f"Unexpected {err=}, {type(err)=}")
-            raise
-        return dt_string, time_diff, status_code_dict
-
     def validate_example_data_manifest(self):
         """
         validating an example data manifest
@@ -81,8 +48,8 @@ class ValidateManifest:
         for opt in restrict_rules_opt:
             params["restrict_rules"] = opt
 
-            dt_string, time_diff, status_code_dict = self.send_post_request(
-                self.send_example_patient_manifest_to_validate
+            dt_string, time_diff, status_code_dict = send_post_request(
+                params, base_url, CONCURRENT_THREADS, send_example_patient_manifest
             )
 
             record_run_time_result(
@@ -102,8 +69,8 @@ class ValidateManifest:
         # update parameter. For this example, validate a Biospecimen manifest
         params["data_type"] = "Biospecimen"
 
-        dt_string, time_diff, status_code_dict = self.send_post_request(
-            self.send_HTAN_biospecimen_manifest_to_validate
+        dt_string, time_diff, status_code_dict = send_post_request(
+            params, base_url, CONCURRENT_THREADS, send_example_patient_manifest
         )
 
         record_run_time_result(

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -39,6 +39,49 @@ def fetch(url: str, params: dict):
     return requests.get(url, params=params)
 
 
+def send_example_patient_manifest(url: str, params: dict):
+    """
+    sending an example patient manifest to validate
+    """
+    return requests.post(
+        url,
+        params=params,
+        files={
+            "file_name": open(
+                "test_manifests/synapse_storage_manifest_patient.csv", "rb"
+            )
+        },
+    )
+
+
+def send_post_request(
+    params: dict, base_url: str, concurrent_threads: int, manifest_to_validate_funct
+):
+    """
+    sending post requests to manifest/validate endpoint
+    Args:
+        params: a dictionary of parameters to send
+        base_url: url of endpoint
+        concurrent_threads: number of concurrent threads
+        manifest_to_validate_funct: a function; a function call that determines
+    Return:
+        dt_string: start time of running the API endpoints.
+        time_diff: time of finish running all requests.
+        all_status_code: dict; a dictionary that records the status code of run.
+    """
+    try:
+        # send request and calculate run time
+        dt_string, time_diff, status_code_dict = cal_time_api_call_post_request(
+            base_url, params, concurrent_threads, manifest_to_validate_funct
+        )
+    # TO DO: add more details about raising different exception
+    # Should exception based on response type?
+    except Exception as err:
+        print(f"Unexpected {err=}, {type(err)=}")
+        raise
+    return dt_string, time_diff, status_code_dict
+
+
 def return_time_now(name_funct_call=None) -> str:
     """
     Get the time now
@@ -138,7 +181,7 @@ def cal_time_api_call_post_request(
     Args:
         url: str; the url that users want to access
         params: dict; the parameters need to use for the request
-        concurrent_thread: integer; number of concurrent threads requested by users
+        concurrent_threads: integer; number of concurrent threads requested by users
     return:
         dt_string: start time of running the API endpoints.
         time_diff: time of finish running all requests.


### PR DESCRIPTION
Highlight: 
* Test submitting an example patient manifest with manifest_record_type = "file_only" or "table_and_file" and with restrict_rules = True or restrict_rules = False
* refactor `manifest-validate.py` so that some functions could be used for`manifest-submit.py`