### PR TITLE
Added test to benchmark /storage/assets/tables

### DIFF
--- a/APITests/manifest-generator.py
+++ b/APITests/manifest-generator.py
@@ -1,4 +1,4 @@
-from utils import get_input_token, cal_time_api_call, record_run_time_result
+from utils import get_input_token, record_run_time_result, send_request
 from utils import HTAN_SCHEMA_URL, EXAMPLE_SCHEMA_URL, BASE_URL
 
 CONCURRENT_THREADS = 1
@@ -22,31 +22,11 @@ class GenerateExampleManifest:
             "input_token": self.token,
         }
 
-    def send_request(self):
-        """
-        sending requests to manifest/generate endpoint
-        Return:
-            dt_string: start time of running the API endpoints.
-            time_diff: time of finish running all requests.
-            all_status_code: dict; a dictionary that records the status code of run.
-        """
-        try:
-            # send request and calculate run time
-            dt_string, time_diff, status_code_dict = cal_time_api_call(
-                base_url, self.params, CONCURRENT_THREADS
-            )
-        # TO DO: add more details about raising different exception
-        # Should exception based on response type?
-        except Exception as err:
-            print(f"Unexpected {err=}, {type(err)=}")
-            raise
-        return dt_string, time_diff, status_code_dict
-
     def generate_new_manifest_example_model(self):
         """
         Generate a new manifest as a google sheet by using the example data model
         """
-        dt_string, time_diff, status_code_dict = self.send_request()
+        dt_string, time_diff, status_code_dict = send_request()
 
         record_run_time_result(
             "manifest/generate",
@@ -66,7 +46,7 @@ class GenerateExampleManifest:
         params = self.params
         params["output"] = output_format
 
-        dt_string, time_diff, status_code_dict = self.send_request()
+        dt_string, time_diff, status_code_dict = send_request()
 
         record_run_time_result(
             "manifest/generate",
@@ -81,7 +61,7 @@ class GenerateExampleManifest:
         """
         Generate a new manifest as a google sheet by using the HTAN manifest
         """
-        dt_string, time_diff, status_code_dict = self.send_request()
+        dt_string, time_diff, status_code_dict = send_request()
 
         record_run_time_result(
             "manifest/generate",
@@ -100,7 +80,7 @@ class GenerateExampleManifest:
         params["dataset_id"] = "syn51078367"
         params["asset_view"] = "syn23643253"
 
-        dt_string, time_diff, status_code_dict = self.send_request()
+        dt_string, time_diff, status_code_dict = send_request()
 
         record_run_time_result(
             "manifest/generate",

--- a/APITests/manifest-storage.py
+++ b/APITests/manifest-storage.py
@@ -1,0 +1,46 @@
+from utils import (
+    get_input_token,
+    cal_time_api_call,
+    record_run_time_result,
+    send_request,
+)
+from utils import HTAN_SCHEMA_URL, EXAMPLE_SCHEMA_URL, BASE_URL
+
+CONCURRENT_THREADS = 1
+
+
+class ManifestStorageAPI:
+    def __init__(self):
+        self.token = get_input_token()
+        self.params = {"input_token": self.token}
+
+    def retrieve_asset_view_as_json(self):
+        """
+        Retrieve asset view table as a dataframe.
+        """
+        # define base_url
+        base_url = f"{BASE_URL}/storage/assets/tables"
+        # define the asset view to retrieve
+        asset_view = "syn23643253"
+        params = self.params
+        params["asset_view"] = asset_view
+
+        # calculate latency for different return type
+        # TO DO: add csv
+        params["return_type"] = "json"
+        dt_string, time_diff, status_code_dict = send_request(
+            params, base_url, CONCURRENT_THREADS
+        )
+
+        record_run_time_result(
+            "storage/assets/tables",
+            dt_string,
+            f"Retrieve asset view {asset_view} as a json",
+            time_diff,
+            CONCURRENT_THREADS,
+            status_code_dict,
+        )
+
+
+manifest_storage_class = ManifestStorageAPI()
+manifest_storage_class.retrieve_asset_view_as_json()

--- a/APITests/manifest-storage.py
+++ b/APITests/manifest-storage.py
@@ -4,7 +4,7 @@ from utils import (
     record_run_time_result,
     send_request,
 )
-from utils import HTAN_SCHEMA_URL, EXAMPLE_SCHEMA_URL, BASE_URL
+from utils import BASE_URL
 
 CONCURRENT_THREADS = 1
 

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -82,6 +82,31 @@ def send_post_request(
     return dt_string, time_diff, status_code_dict
 
 
+def send_request(params: dict, base_url: str, concurrent_threads: int):
+    """
+    sending requests to manifest/generate endpoint
+    Args:
+        params: a dictionary of parameters to send
+        base_url: url of endpoint
+        concurrent_threads: number of concurrent threads
+    Return:
+        dt_string: start time of running the API endpoints.
+        time_diff: time of finish running all requests.
+        all_status_code: dict; a dictionary that records the status code of run.
+    """
+    try:
+        # send request and calculate run time
+        dt_string, time_diff, status_code_dict = cal_time_api_call(
+            base_url, params, concurrent_threads
+        )
+    # TO DO: add more details about raising different exception
+    # Should exception based on response type?
+    except Exception as err:
+        print(f"Unexpected {err=}, {type(err)=}")
+        raise
+    return dt_string, time_diff, status_code_dict
+
+
 def return_time_now(name_funct_call=None) -> str:
     """
     Get the time now


### PR DESCRIPTION
Highlight: 
* Added test to benchmark `/storage/assets/tables` endpoint
* Move `send_request` from generator to utils.py