### PR TITLE
Fixed using `send_request` in manifest-generator.py and added test to run in workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,5 +33,5 @@ jobs:
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        run: python3 APITests/manifest-generator.py APITests/manifest-submit.py APITests/manifest-validate.py 
+        run: python3 APITests/manifest-generator.py APITests/manifest-submit.py APITests/manifest-validate.py APITest/manifest-storage.py
 

--- a/APITests/manifest-generator.py
+++ b/APITests/manifest-generator.py
@@ -26,7 +26,9 @@ class GenerateExampleManifest:
         """
         Generate a new manifest as a google sheet by using the example data model
         """
-        dt_string, time_diff, status_code_dict = send_request()
+        dt_string, time_diff, status_code_dict = send_request(
+            base_url, self.params, CONCURRENT_THREADS
+        )
 
         record_run_time_result(
             "manifest/generate",
@@ -46,7 +48,9 @@ class GenerateExampleManifest:
         params = self.params
         params["output"] = output_format
 
-        dt_string, time_diff, status_code_dict = send_request()
+        dt_string, time_diff, status_code_dict = send_request(
+            base_url, self.params, CONCURRENT_THREADS
+        )
 
         record_run_time_result(
             "manifest/generate",
@@ -61,7 +65,9 @@ class GenerateExampleManifest:
         """
         Generate a new manifest as a google sheet by using the HTAN manifest
         """
-        dt_string, time_diff, status_code_dict = send_request()
+        dt_string, time_diff, status_code_dict = send_request(
+            base_url, self.params, CONCURRENT_THREADS
+        )
 
         record_run_time_result(
             "manifest/generate",
@@ -80,7 +86,9 @@ class GenerateExampleManifest:
         params["dataset_id"] = "syn51078367"
         params["asset_view"] = "syn23643253"
 
-        dt_string, time_diff, status_code_dict = send_request()
+        dt_string, time_diff, status_code_dict = send_request(
+            base_url, self.params, CONCURRENT_THREADS
+        )
 
         record_run_time_result(
             "manifest/generate",


### PR DESCRIPTION
Highlights: 
* Fixed using `send_request` in `manifest-generator.py`
* Added `manifest-storage.py` to be run in workflow