### PR TITLE
Added test for /storage/project/dataset endpoint

### DIFF
--- a/APITests/manifest-storage.py
+++ b/APITests/manifest-storage.py
@@ -1,6 +1,5 @@
 from utils import (
     get_input_token,
-    cal_time_api_call,
     record_run_time_result,
     send_request,
 )
@@ -14,6 +13,8 @@ class ManifestStorageAPI:
         self.token = get_input_token()
         self.params = {"input_token": self.token}
 
+
+class RetrieveAssetView(ManifestStorageAPI):
     def retrieve_asset_view_as_json(self):
         """
         Retrieve asset view table as a dataframe.
@@ -41,17 +42,19 @@ class ManifestStorageAPI:
             status_code_dict=status_code_dict,
         )
 
-    def retrieve_project_datasets(self):
-        """
-        Retrieve all datasets under a given project
-        """
-        # define base_url
-        base_url = f"{BASE_URL}/storage/project/datasets"
 
-        # define the asset view to retrieve
+class RestrieveProjectDataset(ManifestStorageAPI):
+    def retrieve_project_dataset_api_call(self, project_id: str, asset_view: str):
+        """
+        Make the API calls to retrieve all datasets from a given project
+        Args:
+            project_id: ID of a storage project.
+            asset_view: ID of view listing all project data assets.
+        """
+        base_url = f"{BASE_URL}/storage/project/datasets"
         params = self.params
-        asset_view = "syn23643253"
-        project_id = "syn26251192"
+
+        # update parameter
         params["asset_view"] = asset_view
         params["project_id"] = project_id
 
@@ -68,7 +71,30 @@ class ManifestStorageAPI:
             status_code_dict=status_code_dict,
         )
 
+    def retrieve_project_datasets_test(self):
+        """
+        Retrieve all datasets under a given example project
+        """
+        # define the asset view to retrieve
+        asset_view = "syn23643253"
+        project_id = "syn26251192"
 
-manifest_storage_class = ManifestStorageAPI()
-manifest_storage_class.retrieve_asset_view_as_json()
-manifest_storage_class.retrieve_project_datasets()
+        self.retrieve_project_dataset_api_call(project_id, asset_view)
+
+    def retrieve_project_datasets_HTAN(self):
+        """
+        Retrieve all datasets under a given testing HTAN project (used by DCA)
+        """
+        # define the asset view to retrieve
+        asset_view = "syn20446927"  # htan asset view
+        project_id = "syn32596076"  # htan center c
+
+        self.retrieve_project_dataset_api_call(project_id, asset_view)
+
+
+retrieve_asset_view_class = RetrieveAssetView()
+retrieve_asset_view_class.retrieve_asset_view_as_json()
+
+retrieve_project_dataset = RestrieveProjectDataset()
+retrieve_project_dataset.retrieve_project_datasets_test()
+retrieve_project_dataset.retrieve_project_datasets_HTAN()

--- a/APITests/manifest-storage.py
+++ b/APITests/manifest-storage.py
@@ -41,6 +41,34 @@ class ManifestStorageAPI:
             status_code_dict=status_code_dict,
         )
 
+    def retrieve_project_datasets(self):
+        """
+        Retrieve all datasets under a given project
+        """
+        # define base_url
+        base_url = f"{BASE_URL}/storage/project/datasets"
+
+        # define the asset view to retrieve
+        params = self.params
+        asset_view = "syn23643253"
+        project_id = "syn26251192"
+        params["asset_view"] = asset_view
+        params["project_id"] = project_id
+
+        dt_string, time_diff, status_code_dict = send_request(
+            base_url, params, CONCURRENT_THREADS
+        )
+
+        record_run_time_result(
+            endpoint_name="storage/project/datasets",
+            description=f"Retrieve all datasets under project {project_id} in asset view {asset_view} as a json",
+            dt_string=dt_string,
+            num_concurrent=CONCURRENT_THREADS,
+            latency=time_diff,
+            status_code_dict=status_code_dict,
+        )
+
 
 manifest_storage_class = ManifestStorageAPI()
 manifest_storage_class.retrieve_asset_view_as_json()
+manifest_storage_class.retrieve_project_datasets()


### PR DESCRIPTION
Highlight: 
* Added two tests for /storage/project/dataset endpoint. One test involves using HTAN file view and HTAN center c
* Added a general method: `retrieve_project_dataset_api_call`, so that it becomes easier to add subsequent tests in case there are new one. 