### PR TITLE
Updated pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
 repos:
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
         language_version: python3.10
--   repo: https://github.com/pycqa/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
-        name: isort (python)


### PR DESCRIPTION
For some reasons, when trying to use `isort` pre-commit hook, it kept trying to fix one of my python files without actually making any changes. Try updating the syntax and see if that could fix it. 

Syntax was borrowed from: https://github.com/PyCQA/isort/blob/main/.pre-commit-config.yaml