### PR TITLE
Updated data flow schema url 

### DIFF
--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -43,7 +43,7 @@ def fetch(url: str, params: dict, headers: dict = None) -> Response:
     Returns:
         Response: a response object
     """
-    return requests.get(url, params=params, headers=headers, verify=False)
+    return requests.get(url, params=params, headers=headers)
 
 
 def send_example_patient_manifest(

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -28,7 +28,8 @@ HTAN_SCHEMA_URL = (
     "https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld"
 )
 
-DATA_FLOW_SCHEMA_URL = "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_model/dataflow_component.jsonld"
+DATA_FLOW_SCHEMA_URL = "https://raw.githubusercontent.com/Sage-Bionetworks/data_flow/main/inst/data_model/dataflow_component.csv"
+
 BASE_URL = "https://schematic-dev.api.sagebionetworks.org/v1"
 
 
@@ -42,7 +43,8 @@ def fetch(url: str, params: dict, headers: dict = None) -> Response:
     Returns:
         Response: a response object
     """
-    return requests.get(url, params=params, headers=headers)
+    logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+    return requests.get(url, params=params, headers=headers, verify=False)
 
 
 def send_example_patient_manifest(

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -43,7 +43,6 @@ def fetch(url: str, params: dict, headers: dict = None) -> Response:
     Returns:
         Response: a response object
     """
-    logging.basicConfig(level=logging.DEBUG, format="%(message)s")
     return requests.get(url, params=params, headers=headers, verify=False)
 
 


### PR DESCRIPTION
## Context
Related to: [FDS-1705](https://sagebionetworks.jira.com/browse/FDS-1705)

When using the existing DFA json-ld schema url to submit, I got the following error: 
```
INFO:werkzeug:127.0.0.1 - - [12/Feb/2024 11:52:20] "POST /v1/model/submit?schema_url=https%3A%2F%2Fraw.githubusercontent.com%2FSage-Bionetworks%2Fdata_flow%2Fmain%2Finst%2Fdata_model%2Fdataflow_component.jsonld&dataset_id=syn51376664&manifest_record_type=file_only&restrict_rules=false&hide_blanks=false&asset_view=syn51376649&table_manipulation=replace&table_column_names=class_label&annotation_keys=class_label HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 1519, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 1517, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/flask/app.py", line 1503, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/decorators/decorator.py", line 68, in wrapper
    response = function(request)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/security/security_handler_factory.py", line 388, in wrapper
    return function(request)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/decorators/uri_parsing.py", line 149, in wrapper
    response = function(request)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/decorators/validation.py", line 196, in wrapper
    response = function(request)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/decorators/validation.py", line 399, in wrapper
    return function(request)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/connexion/decorators/parameter.py", line 120, in wrapper
    return function(**kwargs)
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic_api/api/routes.py", line 404, in submit_manifest_route
    metadata_model = initalize_metadata_model(schema_url)
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic_api/api/routes.py", line 217, in initalize_metadata_model
    metadata_model = MetadataModel(
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic/models/metadata.py", line 59, in __init__
    parsed_data_model = data_model_parser.parse_model()
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic/schemas/data_model_parser.py", line 100, in parse_model
    model_dict = jsonld_parser.parse_jsonld_model(self.path_to_data_model)
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic/schemas/data_model_parser.py", line 485, in parse_jsonld_model
    model_dict = self.gather_jsonld_attributes_relationships(json_load["@graph"])
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic/schemas/data_model_parser.py", line 357, in gather_jsonld_attributes_relationships
    dn_label_dict = self.label_to_dn_dict(model_jsonld=model_jsonld)
  File "/Users/lpeng/Documents/schematic-git2/schematic/schematic/schemas/data_model_parser.py", line 302, in label_to_dn_dict
    dn_label_dict[entry[label_jsonld_key]] = entry[dn_jsonld_key]
KeyError: 'sms:displayName'
```
This is because after schematic schema refactor, DFA needs to re-run the convert command. Since schematic could now accept CSV url, I updated schematic profiler to just use the CSV data model. 

## Solution
Updated DFA url to use csv version of data model

[FDS-1705]: https://sagebionetworks.jira.com/browse/FDS-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ