### PR TITLE
cancel in progress actions when there's a newer action running

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,4 @@
 name: aws-api-test
-
-# Only trigger, when the build workflow succeeded
 on:
   workflow_dispatch: # allow workflow to be manually triggered
   repository_dispatch:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,12 +1,22 @@
 name: aws-api-test
 
+# Only trigger, when the build workflow succeeded
 on:
-  push:
-    branches: ['develop']
   workflow_dispatch: # allow workflow to be manually triggered
   repository_dispatch:
     types: [trigger-profiler]
-
+concurrency:
+  # cancel the current running workflow from the same branch, PR when a new workflow is triggered
+  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag
+  # {{ github.event.pull_request.number}}: get PR number
+  # {{ github.sha }}: full commit sha
+  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 jobs:
   Benchmarch-Latency:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Cancel in-progress github actions running if there's a newer action running. 
* Avoid running profiler simply because there's a push to develop. I think that's not the use case any more. The most common use case is to run the profiler after deploying to AWS dev. 