### PR TITLE
Fixed synapse login issue after updating synapsepythonclient version

### DIFF
--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -182,7 +182,7 @@ def login_synapse() -> synapseclient.Synapse:
         syn = synapseclient.Synapse()
 
         # syn.default_headers["Authorization"] = f"Bearer {token}"
-        syn.login(rememberMe=True)
+        syn.login()
     except (
         synapseclient.core.exceptions.SynapseNoCredentialsError,
         synapseclient.core.exceptions.SynapseHTTPError,


### PR DESCRIPTION
Got the following errors after updating synapse python client version: 
```
Traceback (most recent call last):
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest-storage.py", line 98, in <module>
    retrieve_asset_view_class.retrieve_asset_view_as_json()
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest-storage.py", line 36, in retrieve_asset_view_as_json
    record_run_time_result(
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/utils.py", line 329, in record_run_time_result
    syn = login_synapse()
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/utils.py", line 185, in login_synapse
    syn.login(rememberMe=True)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
TypeError: Synapse.login() got an unexpected keyword argument 'rememberMe'
```

Fixed it by removing the `rememberMe` option. 