### PR TITLE
Reduce profiler run time

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,11 +27,15 @@ jobs:
         with:
           python-version: "3.10"
           cache: 'pip' # caching pip dependencies
-      - run: |
+
+      - name: Activate a virtual environment
+        run: |
           pip install --upgrade pip
           python3.10 -m venv venv
           source venv/bin/activate
-          pip install -r requirements.txt
+
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt
 
       - name: Run all benchmark tests
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   Benchmarch-Latency:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,21 +20,18 @@ jobs:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-
-      - name: Activate a virtual environment
-        run: |
+          cache: 'pip' # caching pip dependencies
+      - run: |
           pip install --upgrade pip
           python3.10 -m venv venv
           source venv/bin/activate
-
-      - name: Install dependencies
-        run: pip3 install -r requirements.txt
+          pip install -r requirements.txt
 
       - name: Run all benchmark tests
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,6 +44,4 @@ jobs:
         run:
           |
           cd APITests
-          python3 manifest-storage.py
-          python3 manifest-validate.py
-          python3 manifest-submit.py
+          python3 multi-processing.py

--- a/APITests/multi-processing.py
+++ b/APITests/multi-processing.py
@@ -1,0 +1,26 @@
+import multiprocessing
+import subprocess
+
+
+def run_script(script):
+    # Execute the script
+    subprocess.run(["python3", script])
+
+
+if __name__ == "__main__":
+    scripts = [
+        "manifest-validate.py",
+        "manifest-storage.py",
+        "manifest-submit.py",
+        "manifest-generator.py",
+    ]
+
+    # Create a multiprocessing pool
+    pool = multiprocessing.Pool(processes=len(scripts))
+
+    # Run scripts in parallel
+    pool.map(run_script, scripts)
+
+    # Close the pool
+    pool.close()
+    pool.join()


### PR DESCRIPTION
## Context
### Configure profiler to use a larger runner 
For running all the benchmark tests, schematic profiler takes around 40 min to run in github action. (It takes a much shorter time to run locally, but for some reasons, it takes much longer to run in github action. ) I updated the profiler to run on a larger runner to speed things up. 

Before using a larger runner: 

<img width="1388" alt="Screen Shot 2024-02-27 at 4 37 44 PM" src="https://github.com/Sage-Bionetworks/schematic_profiler/assets/55448354/c1630f1f-5a1d-46c3-88cb-31277d60e54b">

After using a larger runner: 
<img width="1411" alt="Screen Shot 2024-02-27 at 4 59 30 PM" src="https://github.com/Sage-Bionetworks/schematic_profiler/assets/55448354/a70cf4fc-2c5f-41c6-838e-e60b10c09ded">

That could speed up the time by half. 

Related to: https://sagebionetworks.jira.com/browse/FDS-1800

### Configure profiler to run python scripts in parallel
And also try running python scripts in parallel and see if run time can be reduced.

