### PR TITLE
Combine functions of sending manifests

### DIFF
--- a/APITests/manifest_submit.py
+++ b/APITests/manifest_submit.py
@@ -11,8 +11,7 @@ from utils import (
     EXAMPLE_SCHEMA_URL,
     StoreRuntime,
     save_run_time_result,
-    send_example_patient_manifest,
-    send_HTAN_dataflow_manifest,
+    send_manifest,
     send_post_request,
 )
 
@@ -50,6 +49,7 @@ class ManifestSubmit:
         description: str,
         manifest_to_send_func: Callable[[str, dict], Response],
         headers: dict,
+        file_path_manifest: str,
     ) -> MultiRow:
         """
         Submitting a manifest with different parameters set by users and record latency
@@ -60,6 +60,7 @@ class ManifestSubmit:
             description (str): a short description of what the submission is. I.E. submitting XX manifest as
             manifest_to_send_func (Callable): a function that sends a post request that upload a manifest to be sent
             headers (dict): headers used for API requests. For example, authorization headers.
+            file_path (str): file path of manifest to send
         """
         combined_list = []
         for opt in data_type_lst:
@@ -72,6 +73,7 @@ class ManifestSubmit:
                     params,
                     CONCURRENT_THREADS,
                     manifest_to_send_func,
+                    file_path_manifest=file_path_manifest,
                     headers=headers,
                 )
 
@@ -125,8 +127,9 @@ class ManifestSubmit:
             record_type_lst,
             params,
             description,
-            send_example_patient_manifest,
+            send_manifest,
             headers=self.headers,
+            file_path_manifest="test_manifests/synapse_storage_manifest_patient.csv",
         )
 
     def submit_dataflow_manifest(self) -> MultiRow:
@@ -145,8 +148,9 @@ class ManifestSubmit:
             record_type_lst,
             params,
             description,
-            send_HTAN_dataflow_manifest,
+            send_manifest,
             headers=self.headers,
+            file_path_manifest="test_manifests/synapse_storage_manifest_dataflow.csv",
         )
 
 

--- a/APITests/manifest_validate.py
+++ b/APITests/manifest_validate.py
@@ -9,8 +9,7 @@ from utils import (
     MultiRow,
     StoreRuntime,
     save_run_time_result,
-    send_example_patient_manifest,
-    send_HTAN_biospecimen_manifest_to_validate,
+    send_manifest,
     send_post_request,
 )
 
@@ -47,7 +46,11 @@ class ManifestValidate:
             params["restrict_rules"] = opt
 
             dt_string, time_diff, status_code_dict = send_post_request(
-                base_url, params, CONCURRENT_THREADS, send_example_patient_manifest
+                base_url,
+                params,
+                CONCURRENT_THREADS,
+                send_manifest,
+                file_path_manifest="test_manifests/synapse_storage_manifest_patient.csv",
             )
 
             result = save_run_time_result(
@@ -79,7 +82,8 @@ class ManifestValidate:
             base_url,
             params,
             CONCURRENT_THREADS,
-            send_HTAN_biospecimen_manifest_to_validate,
+            send_manifest,
+            file_path_manifest="test_manifests/synapse_storage_manifest_HTAN_HMS.csv",
         )
 
         return save_run_time_result(

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -265,7 +265,6 @@ def cal_time_api_call_post_request(
 
     # execute concurrent requests
     with ThreadPoolExecutor() as executor:
-        print("file path manifest", file_path_manifest)
         futures = [
             executor.submit(
                 manifest_to_send_func, url, params, headers, file_path_manifest


### PR DESCRIPTION
## Context
In schematic profiler, sending manifest function  is scattered in a couple of places, including: send_example_patient_manifest, send_HTAN_biospecimen_manifest_to_validate, and send_HTAN_dataflow_manifest. This PR refactors them to be in one function: send_manifest. 

## Test
I tested by running `manifest-submit.py` and `manifest-validate.py` to make sure that requests can be sent to API endpoints without any issues. 