### PR TITLE
feat: compared time expenses of walking different folder structure; and manifest generate with use_annotations

### DIFF
--- a/APITests/annotations_upload_submission_benchmark.py
+++ b/APITests/annotations_upload_submission_benchmark.py
@@ -1,9 +1,9 @@
-
 import logging
 from utils import StoreRuntime, send_manifest, send_post_request
 from test_resources_utils import create_test_files
 
 logger = logging.getLogger("test upload annotations parameter")
+
 
 def execute_submission_comparison(
     dataset_id: str, asset_view_id: str, file_path_manifest: str, num_time: int
@@ -19,7 +19,7 @@ def execute_submission_comparison(
     srt = StoreRuntime()
     token = srt.get_access_token()
     headers = {"Authorization": f"Bearer {token}"}
-    file_annotations_upload_lst = [False]
+    file_annotations_upload_lst = [True, False]
     base_url = "http://localhost:3001/v1/model/submit"
     params = {
         "manifest_record_type": "file_only",
@@ -37,7 +37,7 @@ def execute_submission_comparison(
 
         # try submitting x amount of time and calculate average
         for count in range(num_time):
-            dt_string, time_diff, all_status_code = send_post_request(
+            _, time_diff, all_status_code = send_post_request(
                 base_url, params, 1, send_manifest, file_path_manifest, headers
             )
             if all_status_code["200"] != 1:
@@ -48,7 +48,6 @@ def execute_submission_comparison(
         logger.info(
             f"average time of submitting a manifest when upload_file_annotations set to {i} is: {average_submission_time}"
         )
-
 
 
 test_folder_dir = (

--- a/APITests/annotations_upload_submission_benchmark.py
+++ b/APITests/annotations_upload_submission_benchmark.py
@@ -1,158 +1,12 @@
-import asyncio
+
 import logging
-import os
-import shutil
-from pathlib import Path
-from synapseclient import EntityViewSchema, EntityViewType, Folder, Project
-from synapseclient.models import File
 from utils import StoreRuntime, send_manifest, send_post_request
+from test_resources_utils import create_test_files
 
 logger = logging.getLogger("test upload annotations parameter")
 
-# login to synapse
-srt = StoreRuntime()
-syn = srt.login_synapse()
-
-
-# create a test project
-def create_test_project(project_name: str) -> Project:
-    """create test project
-
-    Args:
-        project_name (str): create test project
-
-    Returns:
-        Project: synapse project
-    """
-    project = Project(name=project_name)
-    project = syn.store(obj=project)
-    return project, project["id"]
-
-
-# create a folder under a project
-def create_test_folder(project: Project) -> Folder:
-    """synapse test folder
-
-    Args:
-        project (Project): synapse project
-
-    Returns:
-        Folder: synapse folder created
-    """
-    data_folder = Folder("Test sub folder", parent=project)
-    data_folder = syn.store(data_folder)
-    return data_folder
-
-
-def create_test_entity_view(project_syn_id: str, project: Project) -> EntityViewSchema:
-    """create test entity view on synapse
-
-    Args:
-        project_syn_id (str): synapse project id
-        project (Project): synapse project
-
-    Returns:
-        EntityViewSchema: entity view created
-    """
-    scopeIds = [project_syn_id]
-    entity_view = EntityViewSchema(
-        name="test view",
-        scopeIds=scopeIds,
-        includeEntityTypes=[EntityViewType.FILE, EntityViewType.FOLDER],
-        parent=project,
-    )
-    entity_view = syn.store(entity_view)
-    return entity_view
-
-
-# maybe changed this file to
-def write_test_file(text_to_write: str, file_path: str) -> None:
-    """write mock test files
-
-    Args:
-        text_to_write (str): test string to write
-        file_path (str): test file path
-    """
-    if not os.path.exists(file_path):
-        with open(file_path, "w") as file:
-            file.write(text_to_write)
-
-
-# create test files locally
-def create_local_test_files(num_test_files: int, test_folder_path: str) -> None:
-    """create local test files
-
-    Args:
-        num_test_files (int): number of test files to be created locally
-        test_folder_path (str): path of local test folder
-    """
-    test_dir = test_folder_path
-    if not os.path.exists(test_dir):
-        os.makedirs(test_dir)
-
-    files = os.listdir(test_dir)
-    current_num_files = len(files)
-    if current_num_files < num_test_files:
-        num_files_to_add = num_test_files - len(files)
-
-        for i in range(current_num_files, current_num_files + num_files_to_add):
-            sample_file = f"{test_dir}/sample_file_{i}.txt"
-            write_test_file("writing test files", sample_file)
-
-
-async def store_test_file_on_syn(
-    syn_dataset: Folder, test_file: str, test_folder: Path
-) -> None:
-    """asynchronously store test files on synapse
-
-    Args:
-        syn_dataset (Folder): synapse dataset folder
-        test_file (Str): test file name
-        test_folder (str): path of test folder
-    """
-    path_test_file = test_folder + "/" + test_file
-    file = File(path=path_test_file)
-    await file.store_async(parent=syn_dataset)
-
-
-async def store_multi_test_files_on_syn(syn_dataset: Folder, test_folder: str) -> None:
-    """store multiple test files on synapse
-
-    Args:
-        test_folder (str): store multiple test files on synapse
-    """
-    # assume directory is called "test files"
-    files = os.listdir(test_folder)
-    for test_file in files:
-        task = store_test_file_on_syn(
-            syn_dataset=syn_dataset, test_folder=test_folder, test_file=test_file
-        )
-        await asyncio.gather(task)
-
-
-def create_test_files(num_file: int, project_name: str, test_folder_path: str) -> None:
-    """create test files in a given folder
-
-    Args:
-        num_file (int): number of test files to create in a folder
-        project_name (str): name of project on synapse
-        test_folder_path (str): path of local test folder
-    """
-    project, project_id = create_test_project(project_name)
-    data_folder = create_test_folder(project)
-    entity_view = create_test_entity_view(project_syn_id=project_id, project=project)
-    create_local_test_files(num_file, test_folder_path)
-    asyncio.run(
-        store_multi_test_files_on_syn(
-            syn_dataset=data_folder, test_folder=test_folder_path
-        )
-    )
-
-    return data_folder.id, project_id, entity_view.id
-
-
 def execute_submission_comparison(
-    dataset_id: str, asset_view_id: str, file_path_manifest: Path, num_time: int
+    dataset_id: str, asset_view_id: str, file_path_manifest: str, num_time: int
 ) -> None:
     """for this use case, only interested in if file_annotations_upload_lst is set to True or False
 
@@ -195,17 +49,6 @@ def execute_submission_comparison(
             f"average time of submitting a manifest when upload_file_annotations set to {i} is: {average_submission_time}"
         )
 
-
-# utils function that are useful in testing process
-def clean_up_tests(item: str):
-    if os.path.exists(item):
-        try:
-            if os.path.isdir(item):
-                shutil.rmtree(item)
-            else:  # remove the file
-                os.remove(item)
-        except Exception as ex:
-            print(ex)
 
 
 test_folder_dir = (

--- a/APITests/folder_structure_benchmark.py
+++ b/APITests/folder_structure_benchmark.py
@@ -1,0 +1,12 @@
+from test_resources_utils import create_test_files
+
+# goal is to figure out how much does it take to walk through different projects with different folder structure
+test_folder_dir = "/workspaces/schematic_profiler/test_files"
+
+dataset_id, project_id, asset_view_id = create_test_files(
+    num_file=10,
+    project_name="API test project - folder structure 1",
+    test_folder_path=test_folder_dir,
+)
+print('dataset id', dataset_id)
+

--- a/APITests/folder_structure_benchmark.py
+++ b/APITests/folder_structure_benchmark.py
@@ -1,12 +1,57 @@
-from test_resources_utils import create_test_files
+import time
+
+from synapseutils import walk
+
+from test_resources_utils import create_multi_layer_test_folders
+from utils import StoreRuntime
+
+
+def calculate_walk_folder_time(project_id: str, repeat: int) -> None:
+    """time it takes to walking different folder
+
+    Args:
+        project_id (str): synapse project ID
+        repeat (int): number of times that you want the walk function to run
+    """
+    srt = StoreRuntime()
+    syn = srt.login_synapse()
+    duration = []
+    for i in range(repeat):
+        start_time = time.time()
+        walk(syn, project_id, includeTypes=["folder", "file"])
+        end_time = time.time()
+        duration.append(end_time - start_time)
+
+    average_submission_time = sum(duration) / len(duration)
+
+    print(
+        f"average time it takes to walk folder after running {repeat} times is: ",
+        average_submission_time,
+    )
+
 
 # goal is to figure out how much does it take to walk through different projects with different folder structure
-test_folder_dir = "/workspaces/schematic_profiler/test_files"
 
-dataset_id, project_id, asset_view_id = create_test_files(
-    num_file=10,
-    project_name="API test project - folder structure 1",
-    test_folder_path=test_folder_dir,
+# case 1: a dataset folder has 3 layer, and each layer has 3 folders
+project_id, asset_view_id = create_multi_layer_test_folders(
+    num_folder_per_layer=2,
+    num_layer=2,
+    project_name="API test project -folder structure 1",
 )
-print('dataset id', dataset_id)
+calculate_walk_folder_time(project_id=project_id, repeat=10)
 
+# case 2: a dataset folder has 5 layer, and each layer has 5 folders
+project_id, asset_view_id = create_multi_layer_test_folders(
+    num_folder_per_layer=5,
+    num_layer=5,
+    project_name="API test project -folder structure 2",
+)
+calculate_walk_folder_time(project_id=project_id, repeat=10)
+
+# case 3: a dataset folder has 10 layers, and each layer has 2 folders
+project_id, asset_view_id = create_multi_layer_test_folders(
+    num_folder_per_layer=2,
+    num_layer=10,
+    project_name="API test project -folder structure 3",
+)
+calculate_walk_folder_time(project_id=project_id, repeat=10)

--- a/APITests/manifeset_generate_benchmark.py
+++ b/APITests/manifeset_generate_benchmark.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Optional
-from utils import send_request
+
 from manifest_generator import GenerateManifest
 from test_resources_utils import create_test_files
+from utils import send_request
 
 logger = logging.getLogger("test manifest generation")
 

--- a/APITests/manifeset_generate_benchmark.py
+++ b/APITests/manifeset_generate_benchmark.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Optional
+from utils import send_request
+from manifest_generator import GenerateManifest
+from test_resources_utils import create_test_files
+
+logger = logging.getLogger("test manifest generation")
+
+
+def execute_manifest_generate_use_annotations_comparison(
+    schema_url: str,
+    data_type: str,
+    num_time: int,
+    asset_view_id: Optional[str],
+    dataset_id: Optional[str],
+) -> None:
+    """compare the run time of generating a manifest
+
+    Args:
+        schema_url (str): schema url
+        data_type (str): data type of the manifest
+        num_time (int): number of times that end endpoint needs to run
+        asset_view_id (Optional[str]): asset view id
+        dataset_id (Optional[str]): dataset id
+    """
+    use_annotations = [True]
+    CONCURRENT_THREADS = 1
+    base_url = (
+        "https://schematic-dev-refactor.api.sagebionetworks.org/v1/manifest/generate"
+    )
+    generation_duration = []
+    for opt in use_annotations:
+        gm = GenerateManifest(url=schema_url, use_annotation=opt, data_type=data_type)
+        gm.params["asset_view"] = asset_view_id
+        gm.params["dataset_id"] = dataset_id
+
+        for count in range(num_time):
+            _, time_diff, all_status_code = send_request(
+                base_url, gm.params, CONCURRENT_THREADS, gm.headers
+            )
+            if all_status_code["200"] != 1:
+                logger.error("encountered an error when generating the manifest")
+            else:
+                generation_duration.append(time_diff)
+        average_generate_time = sum(generation_duration) / len(generation_duration)
+        logger.info(
+            f"average time of generating a manifest when use_annotations set to {opt} is: {average_generate_time}"
+        )
+
+
+# case 1: a dataset folder with 10 dataset files
+test_folder_dir = (
+    "/Users/lpeng/Documents/schematic_profiler/schematic_profiler/test_new_files"
+)
+dataset_id, project_id, asset_view_id = create_test_files(
+    num_file=10,
+    project_name="API manifest generate project",
+    test_folder_path=test_folder_dir,
+)
+print("dataset id", dataset_id)
+print("project id", project_id)
+print("asset view", asset_view_id)
+
+schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
+data_type = "BulkRNA-seqAssay"
+num_time = 10
+execute_manifest_generate_use_annotations_comparison(
+    schema_url=schema_url,
+    data_type=data_type,
+    num_time=num_time,
+    asset_view_id=asset_view_id,
+    dataset_id=dataset_id,
+)
+
+
+# case 2: a dataset folder with 10 dataset files
+test_folder_dir = (
+    "/Users/lpeng/Documents/schematic_profiler/schematic_profiler/test_new_files"
+)
+dataset_id, project_id, asset_view_id = create_test_files(
+    num_file=100,
+    project_name="API manifest generate project 2",
+    test_folder_path=test_folder_dir,
+)
+print("dataset id", dataset_id)
+print("project id", project_id)
+print("asset view", asset_view_id)
+
+schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
+data_type = "BulkRNA-seqAssay"
+num_time = 10
+execute_manifest_generate_use_annotations_comparison(
+    schema_url=schema_url,
+    data_type=data_type,
+    num_time=num_time,
+    asset_view_id=asset_view_id,
+    dataset_id=dataset_id,
+)

--- a/APITests/manifeset_generate_benchmark.py
+++ b/APITests/manifeset_generate_benchmark.py
@@ -23,7 +23,7 @@ def execute_manifest_generate_use_annotations_comparison(
         asset_view_id (Optional[str]): asset view id
         dataset_id (Optional[str]): dataset id
     """
-    use_annotations = [True]
+    use_annotations = [True, False]
     CONCURRENT_THREADS = 1
     base_url = (
         "https://schematic-dev-refactor.api.sagebionetworks.org/v1/manifest/generate"

--- a/APITests/test_resources_utils.py
+++ b/APITests/test_resources_utils.py
@@ -43,6 +43,19 @@ def create_test_folder(project: Project) -> Folder:
     data_folder = syn.store(data_folder)
     return data_folder
 
+def create_nested_test_folder(project: Project, num_layer: int, ) -> Folder: 
+    """create nested test folder
+
+    Args: 
+        project (Project): synapse Project
+        num_layer (int): number of layer of project to be created
+    Returns: 
+        Folder: synapse folder created
+    """
+    data_folder = Folder(f"Test sub folder", parent=project)
+
+
+
 
 def create_test_entity_view(project_syn_id: str, project: Project) -> EntityViewSchema:
     """create test entity view on synapse
@@ -150,7 +163,10 @@ def create_test_files(num_file: int, project_name: str, test_folder_path: str) -
 
     return data_folder.id, project_id, entity_view.id
 
-def create_test_folder_
+def create_nested_test_folder(num_level_to_create: int):
+    """create nested folder structures
+    """
+
 
 def clean_up_tests(item: str):
     if os.path.exists(item):

--- a/APITests/test_resources_utils.py
+++ b/APITests/test_resources_utils.py
@@ -1,0 +1,163 @@
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from synapseclient import EntityViewSchema, EntityViewType, Folder, Project
+from synapseclient.models import File
+from utils import StoreRuntime
+
+logger = logging.getLogger("test upload annotations parameter")
+
+# login to synapse
+srt = StoreRuntime()
+syn = srt.login_synapse()
+
+
+# create a test project
+def create_test_project(project_name: str) -> Project:
+    """create test project
+
+    Args:
+        project_name (str): create test project
+
+    Returns:
+        Project: synapse project
+    """
+    project = Project(name=project_name)
+    project = syn.store(obj=project)
+    return project, project["id"]
+
+
+# create a folder under a project
+def create_test_folder(project: Project) -> Folder:
+    """synapse test folder
+
+    Args:
+        project (Project): synapse project
+
+    Returns:
+        Folder: synapse folder created
+    """
+    data_folder = Folder("Test sub folder", parent=project)
+    data_folder = syn.store(data_folder)
+    return data_folder
+
+
+def create_test_entity_view(project_syn_id: str, project: Project) -> EntityViewSchema:
+    """create test entity view on synapse
+
+    Args:
+        project_syn_id (str): synapse project id
+        project (Project): synapse project
+
+    Returns:
+        EntityViewSchema: entity view created
+    """
+    scopeIds = [project_syn_id]
+    entity_view = EntityViewSchema(
+        name="test view",
+        scopeIds=scopeIds,
+        includeEntityTypes=[EntityViewType.FILE, EntityViewType.FOLDER],
+        parent=project,
+    )
+    entity_view = syn.store(entity_view)
+    return entity_view
+
+
+# maybe changed this file to
+def write_test_file(text_to_write: str, file_path: str) -> None:
+    """write mock test files
+
+    Args:
+        text_to_write (str): test string to write
+        file_path (str): test file path
+    """
+    if not os.path.exists(file_path):
+        with open(file_path, "w") as file:
+            file.write(text_to_write)
+
+
+# create test files locally
+def create_local_test_files(num_test_files: int, test_folder_path: str) -> None:
+    """create local test files
+
+    Args:
+        num_test_files (int): number of test files to be created locally
+        test_folder_path (str): path of local test folder
+    """
+    test_dir = test_folder_path
+    if not os.path.exists(test_dir):
+        os.makedirs(test_dir)
+
+    files = os.listdir(test_dir)
+    current_num_files = len(files)
+    if current_num_files < num_test_files:
+        num_files_to_add = num_test_files - len(files)
+
+        for i in range(current_num_files, current_num_files + num_files_to_add):
+            sample_file = f"{test_dir}/sample_file_{i}.txt"
+            write_test_file("writing test files", sample_file)
+
+
+async def store_test_file_on_syn(
+    syn_dataset: Folder, test_file: str, test_folder: Path
+) -> None:
+    """asynchronously store test files on synapse
+
+    Args:
+        syn_dataset (Folder): synapse dataset folder
+        test_file (Str): test file name
+        test_folder (str): path of test folder
+    """
+    path_test_file = test_folder + "/" + test_file
+    file = File(path=path_test_file)
+    await file.store_async(parent=syn_dataset)
+
+
+async def store_multi_test_files_on_syn(syn_dataset: Folder, test_folder: str) -> None:
+    """store multiple test files on synapse
+
+    Args:
+        test_folder (str): store multiple test files on synapse
+    """
+    # assume directory is called "test files"
+    files = os.listdir(test_folder)
+    for test_file in files:
+        task = store_test_file_on_syn(
+            syn_dataset=syn_dataset, test_folder=test_folder, test_file=test_file
+        )
+        await asyncio.gather(task)
+
+
+def create_test_files(num_file: int, project_name: str, test_folder_path: str) -> None:
+    """create test files in a given folder
+
+    Args:
+        num_file (int): number of test files to create in a folder
+        project_name (str): name of project on synapse
+        test_folder_path (str): path of local test folder
+    """
+    project, project_id = create_test_project(project_name)
+    data_folder = create_test_folder(project)
+    entity_view = create_test_entity_view(project_syn_id=project_id, project=project)
+    create_local_test_files(num_file, test_folder_path)
+    asyncio.run(
+        store_multi_test_files_on_syn(
+            syn_dataset=data_folder, test_folder=test_folder_path
+        )
+    )
+
+    return data_folder.id, project_id, entity_view.id
+
+def create_test_folder_
+
+def clean_up_tests(item: str):
+    if os.path.exists(item):
+        try:
+            if os.path.isdir(item):
+                shutil.rmtree(item)
+            else:  # remove the file
+                os.remove(item)
+        except Exception as ex:
+            print(ex)


### PR DESCRIPTION
## Context
Related to: https://sagebionetworks.jira.com/browse/FDS-1539

## What's changed
* Added functionality to create test folders in different structure
* Organized code related to creating test resources in a separate file
* Added functionality to run manifest_generate while comparing (use_annotation) option

## Confluence page documentation 
https://sagebionetworks.jira.com/wiki/x/DYB1xQ