### PR TITLE
fix: Fix file path in github action 

### DIFF
--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -88,7 +88,7 @@ def send_manifest(
         Response: a response object
     """
     wd = os.getcwd()
-    test_manifest_path = os.path.join(wd, "APITests", manifest_path)
+    test_manifest_path = os.path.join(wd, manifest_path)
 
     if not os.path.exists(test_manifest_path):
         logger.error(


### PR DESCRIPTION
Fix file path in GH action because of the error here: https://github.com/Sage-Bionetworks/schematic_profiler/actions/runs/8840791862/job/24276742881

More details: 
```
Traceback (most recent call last):
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/run_all_parallel.py", line 3, in <module>
Unexpected err=FileNotFoundError(2, 'No such file or directory'), type(err)=<class 'FileNotFoundError'>
    from manifest_submit import monitor_manifest_submission
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest_submit.py", line 168, in <module>
    monitor_manifest_submission()
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest_submit.py", line 160, in monitor_manifest_submission
    rows = sm_example_manifest.submit_example_manifeset_patient()
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest_submit.py", line 1[25](https://github.com/Sage-Bionetworks/schematic_profiler/actions/runs/8840791862/job/24276742881#step:6:26), in submit_example_manifeset_patient
    return self.execute_manifest_submission(
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/manifest_submit.py", line 71, in execute_manifest_submission
    dt_string, time_diff, status_code_dict = send_post_request(
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/utils.py", line 132, in send_post_request
    dt_string, time_diff, status_code_dict = cal_time_api_call_post_request(
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/utils.py", line [27](https://github.com/Sage-Bionetworks/schematic_profiler/actions/runs/8840791862/job/24276742881#step:6:28)7, in cal_time_api_call_post_request
    status_code = f.result().status_code
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/runner/work/schematic_profiler/schematic_profiler/APITests/utils.py", line 102, in send_manifest
    files=***"file_name": open(test_manifest_path, "rb")***,
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/schematic_profiler/schematic_profiler/APITests/APITests/test_manifests/synapse_storage_manifest_patient.csv'
```