### PR TITLE
feat: add verify=false when sending requests 

### DIFF
--- a/APITests/manifest_generator.py
+++ b/APITests/manifest_generator.py
@@ -137,3 +137,6 @@ def monitor_manifest_generator() -> Tuple[Row, Row, Row, Row]:
     row_four = gm_htan.generate_new_manifest_HTAN_google_sheet()
 
     return row_one, row_two, row_three, row_four
+
+
+monitor_manifest_generator()

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -12,6 +12,7 @@ import synapseclient
 from requests import Response
 from requests.exceptions import InvalidSchema
 from synapseclient import Table
+from urllib3.exceptions import InsecureRequestWarning
 
 
 # Create a custom formatter with colors
@@ -59,6 +60,10 @@ BASE_URL = "https://schematic-dev.api.sagebionetworks.org/v1"
 # define type Row
 Row = List[Union[str, int, dict, bool]]
 MultiRow = List[Row]
+
+
+# Suppress only the single warning from urllib3 needed.
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
 
 def fetch(url: str, params: dict, headers: dict = None) -> Response:

--- a/APITests/utils.py
+++ b/APITests/utils.py
@@ -71,7 +71,7 @@ def fetch(url: str, params: dict, headers: dict = None) -> Response:
     Returns:
         Response: a response object
     """
-    response = requests.get(url, params=params, headers=headers)
+    response = requests.get(url, params=params, headers=headers, verify=False)
     return response
 
 
@@ -100,6 +100,7 @@ def send_manifest(
         params=params,
         headers=headers,
         files={"file_name": open(test_manifest_path, "rb")},
+        verify=False,
     )
 
 


### PR DESCRIPTION
## Context
Without `verify=false`, by default Python looks for SSL certificate when sending requests: 
```
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='a4cceaf4091e34c4dae17f6dabce99ef-1730825910.us-east-1.elb.amazonaws.com', port=443): Max retries exceeded with url: /v1/model/submit?schema_url=https%3A%2F%2Fraw.githubusercontent.com%2FSage-Bionetworks%2Fschematic%2Fdevelop%2Ftests%2Fdata%2Fexample.model.jsonld&dataset_id=syn51376664&asset_view=syn51376649&restrict_rules=False&use_schema_label=True&data_model_labels=class_label&table_manipulation=replace&manifest_record_type=table_and_file (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1007)')))
```

## Solution
Added verify = False to ignore insecure certificate, and also disable warning related to insecure certificate

## Test
Change base url to:  https://a4cceaf4091e34c4dae17f6dabce99ef-1730825910.us-east-1.elb.amazonaws.com/v1
Run manifest/generator: 
1) cd APITests
2) python3 manifest_generator.py 